### PR TITLE
Adds additional dependencies to the info file.

### DIFF
--- a/dragomans.info.yml
+++ b/dragomans.info.yml
@@ -5,3 +5,6 @@ core: 8.x
 package: Dragomans
 dependencies:
   - Fields:ief_table_view_mode
+  - Entity:auto_entitylabel
+  - Other:exclude_node_title
+


### PR DESCRIPTION
Addresses issue #4 by adding additional dependencies to the info.yml file.

To test, confirm that the dependencies appear when looking for more information module install interface (Drupal Admin -> Extend).  You should need to add the additional dependencies before you will be able to enable the Dragomans module.